### PR TITLE
feat: reduce supported languages to English and Japanese only

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,15 +5,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const greetings = [
         'Hello World!',
-        'Bonjour le monde!',
-        'Hola Mundo!',
-        'Ciao mondo!',
-        'Hallo Welt!',
-        'Olá Mundo!',
-        'Привет мир!',
-        'こんにちは世界!',
-        '你好世界!',
-        'مرحبا بالعالم!'
+        'こんにちは世界!'
     ];
 
     let currentIndex = 0;


### PR DESCRIPTION
Closes #9

## Summary
Simplified the language support to include only English and Japanese as requested.

## Changes
- Updated `script.js` greetings array to remove all languages except English and Japanese
- Reduced from 10 languages to 2 languages

## Testing
The greeting rotation will now cycle between only English and Japanese when the button is clicked.

Generated with [Claude Code](https://claude.ai/code)