### PR TITLE
Rotate Tetris piece clockwise or counter-clockwise based on tap side

### DIFF
--- a/tetris.js
+++ b/tetris.js
@@ -98,7 +98,12 @@ class TetrisGame {
             const dy = touchEndY - this.touchStartY;
 
             if (touchDuration < 200 && Math.abs(dx) < 10 && Math.abs(dy) < 10) {
-                this.rotatePiece();
+                // Tap detected - rotate based on screen side
+                const canvasRect = this.canvas.getBoundingClientRect();
+                const tapX = touchEndX - canvasRect.left;
+                const canvasCenter = canvasRect.width / 2;
+                const clockwise = tapX > canvasCenter;
+                this.rotatePiece(clockwise);
             } else if (Math.abs(dx) > Math.abs(dy)) {
                 if (dx > 30) {
                     this.movePiece(1, 0);
@@ -207,12 +212,21 @@ class TetrisGame {
         }
     }
 
-    rotatePiece() {
+    rotatePiece(clockwise = true) {
         if (!this.currentPiece) return;
 
-        const rotated = this.currentPiece.shape[0].map((_, i) =>
-            this.currentPiece.shape.map(row => row[i]).reverse()
-        );
+        let rotated;
+        if (clockwise) {
+            // Rotate clockwise: transpose then reverse each row
+            rotated = this.currentPiece.shape[0].map((_, i) =>
+                this.currentPiece.shape.map(row => row[i]).reverse()
+            );
+        } else {
+            // Rotate counter-clockwise: reverse each row then transpose
+            rotated = this.currentPiece.shape[0].map((_, i) =>
+                this.currentPiece.shape.map(row => row[row.length - 1 - i])
+            );
+        }
 
         const prevShape = this.currentPiece.shape;
         this.currentPiece.shape = rotated;


### PR DESCRIPTION
## Summary
- Enhances Tetris piece rotation to depend on tap location on the canvas
- Tapping left half rotates piece counter-clockwise
- Tapping right half rotates piece clockwise

## Changes

### Input Handling
- Modified touch tap detection to distinguish screen side tapped
- Calculated tap X coordinate relative to canvas center
- Passed rotation direction parameter to `rotatePiece` accordingly

### Rotation Logic
- Updated `rotatePiece` method to accept a `clockwise` boolean parameter
- Implemented clockwise rotation by transposing and reversing rows
- Implemented counter-clockwise rotation by reversing rows then transposing

## Test plan
- [x] Tap left side of canvas rotates piece counter-clockwise
- [x] Tap right side of canvas rotates piece clockwise
- [x] Swipes and other touch gestures remain unaffected
- [x] Rotation behaves correctly for all piece shapes

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/64f24a4d-b51f-4d90-8bad-6e80784564e2