### PR TITLE
fix: Make special piece blocks fall independently

### DIFF
--- a/tetris.js
+++ b/tetris.js
@@ -554,17 +554,21 @@ class TetrisGame {
         for (let i = this.fallingBlocks.length - 1; i >= 0; i--) {
             const block = this.fallingBlocks[i];
 
-            // Check if block can move down
-            if (block.y + 1 >= this.rows || this.board[block.y + 1][block.x]) {
-                // Block has settled - lock it to the board
-                if (block.y >= 0) {
-                    this.board[block.y][block.x] = block.color;
+            // Keep falling until the block hits something
+            while (true) {
+                // Check if block can move down
+                if (block.y + 1 >= this.rows || this.board[block.y + 1][block.x]) {
+                    // Block has settled - lock it to the board
+                    if (block.y >= 0) {
+                        this.board[block.y][block.x] = block.color;
+                    }
+                    // Remove this block from the falling array
+                    this.fallingBlocks.splice(i, 1);
+                    break;
+                } else {
+                    // Block can still fall
+                    block.y++;
                 }
-                // Remove this block from the falling array
-                this.fallingBlocks.splice(i, 1);
-            } else {
-                // Block can still fall
-                block.y++;
             }
         }
 


### PR DESCRIPTION
Fixed the special piece behavior in the Tetris game. Each block in the broken special piece now falls independently until it hits the bottom of the board or another block, rather than falling in sync.

Resolves #28

🤖 Generated with [Claude Code](https://claude.ai/code)